### PR TITLE
Add auto submit debounce option

### DIFF
--- a/addon/components/kinetic-form.js
+++ b/addon/components/kinetic-form.js
@@ -10,6 +10,7 @@ const {
   set,
   computed,
   assign,
+  run: { debounce },
   A,
   RSVP: { resolve },
   ObjectProxy,
@@ -17,6 +18,7 @@ const {
 } = Ember;
 
 const DEFAULT_COMPONENT_NAME_PROP = 'stringComponent';
+const DEFAULT_AUTO_SUBMIT_DELAY = 700;
 
 const DefinitionDecorator = ObjectProxy.extend(PromiseProxyMixin);
 
@@ -25,6 +27,8 @@ export default Component.extend({
   classNames: ['kinetic-form'],
 
   showErrors: false,
+  autoSubmit: true,
+  autoSubmitDelay: DEFAULT_AUTO_SUBMIT_DELAY,
 
   loadingComponent: 'kinetic-form/loading',
   errorComponent: 'kinetic-form/errors',
@@ -123,6 +127,9 @@ export default Component.extend({
   actions: {
     updateProperty(key, value) {
       set(this, `changeset.${key}`, value);
+      if (!get(this, 'autoSubmit')) { return; }
+      let delay = get(this, 'autoSubmitDelay');
+      debounce(this, this.submitForm, delay);
     },
 
     submit() {

--- a/addon/components/kinetic-form.js
+++ b/addon/components/kinetic-form.js
@@ -108,21 +108,25 @@ export default Component.extend({
       .catch(() => set(this, 'showErrors', true));
   },
 
+  submitForm() {
+    let changeset = get(this, 'changeset');
+    this.validateForm(changeset).then(() => {
+      if (get(changeset, 'isInvalid')) {
+        set(this, 'showErrors', true);
+        return;
+      }
+      set(this, 'showErrors', false);
+      get(this, 'onSubmit')(changeset);
+    });
+  },
+
   actions: {
     updateProperty(key, value) {
       set(this, `changeset.${key}`, value);
     },
 
     submit() {
-      let changeset = get(this, 'changeset');
-      this.validateForm(changeset).then(() => {
-        if (get(changeset, 'isInvalid')) {
-          set(this, 'showErrors', true);
-          return;
-        }
-        set(this, 'showErrors', false);
-        get(this, 'onSubmit')(changeset);
-      });
+      this.submitForm();
     }
   }
 });

--- a/tests/integration/components/kinetic-form-test.js
+++ b/tests/integration/components/kinetic-form-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import EmObject from 'ember-object';
 import { moduleForComponent, test } from 'ember-qunit';
+import { default as settled } from 'ember-test-helpers/wait';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 import page from '../../pages/components/kinetic-form';
@@ -162,11 +163,33 @@ test('calls onSubmit action when user submits the form', function () {
   set(this, 'testDefinition', {});
   page.render(hbs`
     {{kinetic-form
+        autoSubmit=false
         definition=testDefinition
         model=testModel
         onSubmit=(action submitSpy)}}
   `);
   run(() => page.submit());
+  sinon.assert.calledWith(get(this, 'submitSpy'), sinon.match(isChangeset, 'Changeset'));
+});
+
+test('calls onSubmit action when user updates the form', async function () {
+  set(this, 'testDefinition', {
+    schema: {
+      properties: {
+        fieldA: {type: 'string'},
+      }
+    }
+  });
+  page.render(hbs`
+    {{kinetic-form
+        autoSubmit=true
+        autoSubmitDelay=0
+        definition=testDefinition
+        model=testModel
+        onSubmit=(action submitSpy)}}
+  `);
+  run(() => page.stringField.enterText('foobar'));
+  await settled();
   sinon.assert.calledWith(get(this, 'submitSpy'), sinon.match(isChangeset, 'Changeset'));
 });
 


### PR DESCRIPTION
| Property          | Default | Description                               |
|-------------------|---------|-------------------------------------------|
| `autoSubmit`      | `true`  | trigger `onSubmit` when any field updates |
| `autoSubmitDelay` | `700`   | the debounce delay in milliseconds        |