### PR TITLE
Refactor schema parsing

### DIFF
--- a/addon/-schema-form-parser.js
+++ b/addon/-schema-form-parser.js
@@ -1,0 +1,76 @@
+import Ember from 'ember';
+
+const {
+  A,
+  Object: EmberObject,
+  assert,
+  assign,
+  computed,
+  computed: { reads },
+  deprecate,
+  isEmpty,
+  get,
+  typeOf
+} = Ember;
+
+export function normalizeFormElement(element, properties, requiredKeys = []) {
+  let required = A(requiredKeys).includes(element.key);
+  let property = assign({}, properties[element.key]);
+  return assign(property, element, { required });
+}
+
+export function* normalizeFormElements(form, properties, requiredKeys) {
+  let propertyNames = Object.keys(properties);
+  if (isEmpty(form)) { form = ['*']; }
+  for (let item of form) {
+    if (item === '*') {
+      yield* propertyNames
+        .map(key => normalizeFormElement({ key }, properties, requiredKeys));
+    } else {
+      let element = typeOf(item) === 'string' ? { key: item } : item;
+      yield normalizeFormElement(element, properties, requiredKeys);
+    }
+  }
+}
+
+export function* normalizeLegacyFormElements(form, properties, requiredKeys) {
+  deprecate(
+    `When using the 'form' array all properties need to be accounted for.`,
+    false,
+    { id: 'legacy-kinetic-form-use', until: '1.0.0' }
+  );
+  let formOverrides = {};
+  for (let override of form) {
+    formOverrides[override.key] = override;
+  }
+  for (let key of Object.keys(properties)) {
+    let element = formOverrides[key] || { key };
+    yield normalizeFormElement(element, properties, requiredKeys);
+  }
+}
+
+export default EmberObject.extend({
+  type: reads('schema.type'),
+  title: reads('schema.title'),
+  required: reads('schema.required'),
+  properties: reads('schema.properties'),
+
+  elements: computed('{properties,form.[],required.[]}', {
+    get() {
+      let form = get(this, 'form');
+      let properties = get(this, 'properties');
+      let requiredKeys = get(this, 'required');
+      let elements = [...normalizeFormElements(form, properties, requiredKeys)];
+      return elements.length < Object.keys(properties).length
+        ? [...normalizeLegacyFormElements(form, properties, requiredKeys)]
+        : elements;
+    }
+  }),
+
+  init() {
+    this._super(...arguments);
+    let schemaType = get(this, 'type');
+    assert(`${schemaType} in not a supported schema type`, schemaType === 'object');
+    assert('schema have a properties object', get(this, 'properties'));
+  }
+});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.3.0",
-    "ember-cli-htmlbars": "^2.0.3"
+    "ember-cli-htmlbars": "^2.0.3",
+    "ember-maybe-import-regenerator": "^0.1.6"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/tests/integration/components/kinetic-form-test.js
+++ b/tests/integration/components/kinetic-form-test.js
@@ -32,6 +32,7 @@ moduleForComponent('kinetic-form', 'Integration | Component | kinetic form', {
 test('renders different form fields from definition schema', function (assert) {
   set(this, 'testDefinition', {
     schema: {
+      type: 'object',
       properties: {
         fieldA: {type: 'boolean'},
         fieldB: {type: 'number'},
@@ -56,7 +57,7 @@ test('renders different form fields from definition schema', function (assert) {
 
 test('render string field as default type', function (assert) {
   set(this, 'testDefinition', {
-    schema: {properties: {fieldA: {type: 'foobar'}}}
+    schema: {type: 'object', properties: {fieldA: {type: 'foobar'}}}
   });
   page.render(hbs`
     {{kinetic-form
@@ -70,6 +71,7 @@ test('render string field as default type', function (assert) {
 test('can override components', function (assert) {
   set(this, 'testDefinition', {
     schema: {
+      type: 'object',
       properties: {
         fieldA: {type: 'number'},
         fieldB: {type: 'foobar'}
@@ -91,7 +93,7 @@ test('can override components', function (assert) {
 test('shows errors section when changeset has errors', function (assert) {
   let mockChangeset = new Changeset({});
   mockChangeset.addError('base', 'test-error');
-  set(this, 'testDefinition', {});
+  set(this, 'testDefinition', {schema: {type: 'object', properties: {}}});
   set(this, 'mockChangeset', mockChangeset);
   page.render(hbs`
     {{kinetic-form
@@ -107,6 +109,7 @@ test('shows errors section when changeset has errors', function (assert) {
 test('overrides field type from form section of definition', function (assert) {
   set(this, 'testDefinition', {
     schema: {
+      type: 'object',
       properties: {
         fieldA: {type: 'boolean'}
       }
@@ -131,6 +134,7 @@ test('overrides field type from form section of definition', function (assert) {
 test('marks fields as required when listed in required section of schema', function (assert) {
   set(this, 'testDefinition', {
     schema: {
+      type: 'object',
       required: ['fieldB'],
       properties: {
         fieldA: {type: 'boolean'},
@@ -149,7 +153,7 @@ test('marks fields as required when listed in required section of schema', funct
 });
 
 test('displays a form title from title section of schema', function (assert) {
-  set(this, 'testDefinition', {schema: {title: 'test-title'}});
+  set(this, 'testDefinition', {schema: {type: 'object', title: 'test-title', properties: {}}});
   page.render(hbs`
     {{kinetic-form
         definition=testDefinition
@@ -160,7 +164,7 @@ test('displays a form title from title section of schema', function (assert) {
 });
 
 test('calls onSubmit action when user submits the form', function () {
-  set(this, 'testDefinition', {});
+  set(this, 'testDefinition', {schema: {type: 'object', properties: {}}});
   page.render(hbs`
     {{kinetic-form
         autoSubmit=false
@@ -175,6 +179,7 @@ test('calls onSubmit action when user submits the form', function () {
 test('calls onSubmit action when user updates the form', async function () {
   set(this, 'testDefinition', {
     schema: {
+      type: 'object',
       properties: {
         fieldA: {type: 'string'},
       }

--- a/tests/integration/components/semantic-ui-kinetic-form-test.js
+++ b/tests/integration/components/semantic-ui-kinetic-form-test.js
@@ -31,6 +31,7 @@ moduleForComponent('semantic-ui-kinetic-form', 'Integration | Component | semant
 test('renders different form fields from definition schema', function (assert) {
   set(this, 'testDefinition', {
     schema: {
+      type: 'object',
       properties: {
         fieldA: {type: 'boolean'},
         fieldB: {type: 'number'},
@@ -55,7 +56,7 @@ test('renders different form fields from definition schema', function (assert) {
 
 test('render string field as default type', function (assert) {
   set(this, 'testDefinition', {
-    schema: {properties: {fieldA: {type: 'foobar'}}}
+    schema: {type: 'object', properties: {fieldA: {type: 'foobar'}}}
   });
   page.render(hbs`
     {{semantic-ui-kinetic-form
@@ -69,6 +70,7 @@ test('render string field as default type', function (assert) {
 test('can override components', function (assert) {
   set(this, 'testDefinition', {
     schema: {
+      type: 'object',
       properties: {
         fieldA: {type: 'number'},
         fieldB: {type: 'foobar'}
@@ -90,7 +92,7 @@ test('can override components', function (assert) {
 test('shows errors section when changeset has errors', function (assert) {
   let mockChangeset = new Changeset({});
   mockChangeset.addError('base', 'test-error');
-  set(this, 'testDefinition', {});
+  set(this, 'testDefinition', {schema: {type: 'object', properties: {}}});
   set(this, 'mockChangeset', mockChangeset);
   page.render(hbs`
     {{semantic-ui-kinetic-form
@@ -106,6 +108,7 @@ test('shows errors section when changeset has errors', function (assert) {
 test('overrides field type from form section of definition', function (assert) {
   set(this, 'testDefinition', {
     schema: {
+      type: 'object',
       properties: {
         fieldA: {type: 'boolean'}
       }
@@ -130,6 +133,7 @@ test('overrides field type from form section of definition', function (assert) {
 test('marks fields as required when listed in required section of schema', function (assert) {
   set(this, 'testDefinition', {
     schema: {
+      type: 'object',
       required: ['fieldB'],
       properties: {
         fieldA: {type: 'boolean'},
@@ -148,7 +152,7 @@ test('marks fields as required when listed in required section of schema', funct
 });
 
 test('displays a form title from title section of schema', function (assert) {
-  set(this, 'testDefinition', {schema: {title: 'test-title'}});
+  set(this, 'testDefinition', {schema: {type: 'object', title: 'test-title', properties: {}}});
   page.render(hbs`
     {{semantic-ui-kinetic-form
         definition=testDefinition
@@ -159,7 +163,7 @@ test('displays a form title from title section of schema', function (assert) {
 });
 
 test('calls onSubmit action when user submits the form', function () {
-  set(this, 'testDefinition', {});
+  set(this, 'testDefinition', {schema: {type: 'object', properties: {}}});
   page.render(hbs`
     {{semantic-ui-kinetic-form
         definition=testDefinition

--- a/tests/unit/-schema-form-parser-test.js
+++ b/tests/unit/-schema-form-parser-test.js
@@ -1,0 +1,121 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import SchemaFormParser from 'ember-kinetic-form/-schema-form-parser';
+
+module('Unit | Schema Form Parser', function() {
+  test('throws exception with unsupported schema type', function(assert) {
+    assert.throws(() => {
+      SchemaFormParser.create({ schema: { type: 'unsupported' } });
+    });
+  });
+
+  test('proxies data from schema', function(assert) {
+    let subject = SchemaFormParser.create({
+      schema: {
+        type: 'object',
+        title: 'test-title',
+        required: ['test'],
+        properties: { '1': {} }
+      }
+    });
+    assert.equal(subject.get('type'), 'object');
+    assert.equal(subject.get('title'), 'test-title');
+    assert.deepEqual(subject.get('required'), ['test']);
+    assert.deepEqual(subject.get('properties'), {'1': {}});
+  });
+
+  test('parses empty form data', function() {
+    let subject = SchemaFormParser.create({
+      schema: {
+        type: 'object',
+        properties: {
+          '1': { type: 'boolean', title: 'foo' },
+          '2': { type: 'boolean', title: 'bar' },
+          '3': { type: 'boolean', title: 'baz' }
+        }
+      }
+    });
+    sinon.assert.match(subject.get('elements'), [
+      sinon.match({ key: '1', type: 'boolean', title: 'foo' }),
+      sinon.match({ key: '2', type: 'boolean', title: 'bar' }),
+      sinon.match({ key: '3', type: 'boolean', title: 'baz' })
+    ]);
+  });
+
+  test('parses reordered form data', function() {
+    let subject = SchemaFormParser.create({
+      schema: {
+        type: 'object',
+        properties: {
+          '1': { type: 'boolean', title: 'foo' },
+          '2': { type: 'boolean', title: 'bar' },
+          '3': { type: 'boolean', title: 'baz' }
+        }
+      },
+      form: ['2', '1', '3']
+    });
+    sinon.assert.match(subject.get('elements'), [
+      sinon.match({ key: '2', type: 'boolean', title: 'bar' }),
+      sinon.match({ key: '1', type: 'boolean', title: 'foo' }),
+      sinon.match({ key: '3', type: 'boolean', title: 'baz' })
+    ]);
+  });
+
+  test('parses form data with a wildcard', function() {
+    let subject = SchemaFormParser.create({
+      schema: {
+        type: 'object',
+        properties: {
+          '1': { type: 'boolean', title: 'foo' },
+          '2': { type: 'boolean', title: 'bar' },
+          '3': { type: 'boolean', title: 'baz' }
+        }
+      },
+      form: ['*', { type: 'submit' }]
+    });
+    sinon.assert.match(subject.get('elements'), [
+      sinon.match({ key: '1', type: 'boolean', title: 'foo' }),
+      sinon.match({ key: '2', type: 'boolean', title: 'bar' }),
+      sinon.match({ key: '3', type: 'boolean', title: 'baz' }),
+      sinon.match({ type: 'submit', required: false })
+    ]);
+  });
+
+  test('parses required keys', function() {
+    let subject = SchemaFormParser.create({
+      schema: {
+        type: 'object',
+        required: ['2'],
+        properties: {
+          '1': { type: 'boolean', title: 'foo' },
+          '2': { type: 'boolean', title: 'bar' },
+          '3': { type: 'boolean', title: 'baz' }
+        }
+      }
+    });
+    sinon.assert.match(subject.get('elements'), [
+      sinon.match({ key: '1', type: 'boolean', title: 'foo', required: false }),
+      sinon.match({ key: '2', type: 'boolean', title: 'bar', required: true }),
+      sinon.match({ key: '3', type: 'boolean', title: 'baz', required: false })
+    ]);
+  });
+
+  test('parses backwards compatible form data', function() {
+    let subject = SchemaFormParser.create({
+      schema: {
+        type: 'object',
+        properties: {
+          '1': { type: 'boolean', title: 'foo' },
+          '2': { type: 'boolean', title: 'bar' },
+          '3': { type: 'boolean', title: 'baz' }
+        }
+      },
+      form: [{ key: '2', type: 'radio' }]
+    });
+    sinon.assert.match(subject.get('elements'), [
+      sinon.match({ key: '1', type: 'boolean', title: 'foo' }),
+      sinon.match({ key: '2', type: 'radio', title: 'bar' }),
+      sinon.match({ key: '3', type: 'boolean', title: 'baz' })
+    ]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,6 +159,12 @@ amd-name-resolver@0.0.7:
   dependencies:
     ensure-posix-path "^1.0.1"
 
+amd-name-resolver@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz#fc41b3848824b557313897d71f8d5a0184fbe679"
+  dependencies:
+    ensure-posix-path "^1.0.1"
+
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
@@ -587,6 +593,12 @@ babel-plugin-ember-modules-api-polyfill@^2.0.1:
   dependencies:
     ember-rfc176-data "^0.2.7"
 
+babel-plugin-ember-modules-api-polyfill@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz#0c01f359658cfb9c797f705af6b09f6220205ae0"
+  dependencies:
+    ember-rfc176-data "^0.3.0"
+
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
@@ -856,7 +868,7 @@ babel-plugin-undefined-to-void@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz#7f578ef8b78dfae6003385d8417a61eda06e2f81"
 
-babel-polyfill@^6.16.0:
+babel-polyfill@^6.16.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:
@@ -896,6 +908,41 @@ babel-preset-env@^1.5.1:
     babel-plugin-transform-exponentiation-operator "^6.22.0"
     babel-plugin-transform-regenerator "^6.22.0"
     browserslist "^2.1.2"
+    invariant "^2.2.2"
+    semver "^5.3.0"
+
+babel-preset-env@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
+    babel-plugin-transform-es2015-computed-properties "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
+    babel-plugin-transform-es2015-function-name "^6.22.0"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
+    babel-plugin-transform-es2015-object-super "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
+    babel-plugin-transform-exponentiation-operator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^3.2.6"
     invariant "^2.2.2"
     semver "^5.3.0"
 
@@ -1121,6 +1168,21 @@ broccoli-babel-transpiler@^6.0.0, broccoli-babel-transpiler@^6.1.2:
     rsvp "^3.5.0"
     workerpool "^2.2.1"
 
+broccoli-babel-transpiler@^6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.4.2.tgz#f9e453ce664d5735baecabbc50e62c1b93b1796d"
+  dependencies:
+    babel-core "^6.26.0"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-persistent-filter "^1.4.3"
+    clone "^2.0.0"
+    hash-for-dep "^1.2.3"
+    heimdalljs-logger "^0.1.7"
+    json-stable-stringify "^1.0.0"
+    rsvp "^4.8.2"
+    workerpool "^2.3.0"
+
 broccoli-brocfile-loader@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/broccoli-brocfile-loader/-/broccoli-brocfile-loader-0.18.0.tgz#2e86021c805c34ffc8d29a2fb721cf273e819e4b"
@@ -1213,6 +1275,17 @@ broccoli-debug@^0.6.1, broccoli-debug@^0.6.2:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
+broccoli-debug@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.4.tgz#986eb3d2005e00e3bb91f9d0a10ab137210cd150"
+  dependencies:
+    broccoli-plugin "^1.2.1"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    symlink-or-copy "^1.1.8"
+    tree-sync "^1.2.2"
+
 broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.2.4.tgz#409afb94b9a3a6da9fac8134e91e205f40cc7330"
@@ -1250,7 +1323,7 @@ broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^2.0.0:
+broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz#6823c73b675ef78fffa7ab800f083e768b51d449"
   dependencies:
@@ -1321,7 +1394,7 @@ broccoli-middleware@^1.0.0:
     handlebars "^4.0.4"
     mime "^1.2.11"
 
-broccoli-persistent-filter@^1.0.3, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.2.0, broccoli-persistent-filter@^1.4.0, broccoli-persistent-filter@^1.4.2:
+broccoli-persistent-filter@^1.0.3, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.2.0, broccoli-persistent-filter@^1.4.0, broccoli-persistent-filter@^1.4.2, broccoli-persistent-filter@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz#3511bc52fc53740cda51621f58a28152d9911bc1"
   dependencies:
@@ -1423,6 +1496,13 @@ browserslist@^2.1.2:
     caniuse-lite "^1.0.30000718"
     electron-to-chromium "^1.3.18"
 
+browserslist@^3.2.6:
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
+  dependencies:
+    caniuse-lite "^1.0.30000844"
+    electron-to-chromium "^1.3.47"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -1489,6 +1569,10 @@ can-symlink@^1.0.0:
 caniuse-lite@^1.0.30000718:
   version "1.0.30000730"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000730.tgz#26a14ff1b3bfc1f1cb4da75c2c73451b3f1ade1a"
+
+caniuse-lite@^1.0.30000844:
+  version "1.0.30000846"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000846.tgz#2092911eecad71a89dae1faa62bcc202fde7f959"
 
 capture-exit@^1.1.0:
   version "1.2.0"
@@ -2015,6 +2099,10 @@ electron-to-chromium@^1.3.18:
   version "1.3.21"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz#a967ebdcfe8ed0083fc244d1894022a8e8113ea2"
 
+electron-to-chromium@^1.3.47:
+  version "1.3.48"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz#d3b0d8593814044e092ece2108fc3ac9aea4b900"
+
 ember-ajax@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-ajax/-/ember-ajax-3.0.0.tgz#8f21e9da0c1d433cf879aa855fce464d517e9ab5"
@@ -2062,6 +2150,24 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.3.0, e
     broccoli-source "^1.1.0"
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
+
+ember-cli-babel@^6.0.0-beta.4:
+  version "6.14.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.14.1.tgz#796339229035910b625593caffbc2683792ada68"
+  dependencies:
+    amd-name-resolver "1.2.0"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.3.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.26.0"
+    babel-preset-env "^1.7.0"
+    broccoli-babel-transpiler "^6.4.2"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.2"
+    semver "^5.5.0"
 
 ember-cli-broccoli-sane-watcher@^2.0.4:
   version "2.0.4"
@@ -2282,6 +2388,13 @@ ember-cli-version-checker@^2.0.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
+ember-cli-version-checker@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz#305ce102390c66e4e0f1432dea9dc5c7c19fed98"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 ember-cli@~2.14.2:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.14.2.tgz#f2c8c75d486ce6cc6b7ffbc22ebef8b32bb242b7"
@@ -2388,6 +2501,15 @@ ember-load-initializers@^1.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
+ember-maybe-import-regenerator@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz#35d41828afa6d6a59bc0da3ce47f34c573d776ca"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.0.0"
+    ember-cli-babel "^6.0.0-beta.4"
+    regenerator-runtime "^0.9.5"
+
 ember-promise-tools@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-promise-tools/-/ember-promise-tools-1.0.0.tgz#0f3d5bd1cb2b7da4f02abd4cb5cf9bd5399af754"
@@ -2421,6 +2543,10 @@ ember-resolver@^4.0.0:
 ember-rfc176-data@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz#bd355bc9b473e08096b518784170a23388bc973b"
+
+ember-rfc176-data@^0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.3.tgz#27fba08d540a7463a4366c48eaa19c5a44971a39"
 
 ember-router-generator@^1.0.0:
   version "1.2.3"
@@ -3361,6 +3487,15 @@ has@^1.0.1, has@~1.0.1:
 hash-for-dep@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hash-for-dep/-/hash-for-dep-1.2.0.tgz#3bdb883aef0d34e82097ef2f7109b1b401cada6b"
+  dependencies:
+    broccoli-kitchen-sink-helpers "^0.3.1"
+    heimdalljs "^0.2.3"
+    heimdalljs-logger "^0.1.7"
+    resolve "^1.4.0"
+
+hash-for-dep@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/hash-for-dep/-/hash-for-dep-1.2.3.tgz#5ec69fca32c23523972d52acb5bb65ffc3664cab"
   dependencies:
     broccoli-kitchen-sink-helpers "^0.3.1"
     heimdalljs "^0.2.3"
@@ -5046,6 +5181,10 @@ regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
 
+regenerator-runtime@^0.9.5:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
+
 regenerator-transform@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
@@ -5217,6 +5356,10 @@ rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
+rsvp@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.2.tgz#9d5647108735784eb13418cdddb56f75b919d722"
+
 rsvp@~3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.2.1.tgz#07cb4a5df25add9e826ebc67dcc9fd89db27d84a"
@@ -5281,6 +5424,10 @@ semver@^4.1.0:
 semver@^5.1.0, semver@^5.1.1, semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
+semver@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 send@0.15.4:
   version "0.15.4"
@@ -6077,6 +6224,12 @@ wordwrap@~1.0.0:
 workerpool@^2.2.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.2.4.tgz#c9dbe01e103e92df0e8f55356fc860135fbd43b0"
+  dependencies:
+    object-assign "4.1.1"
+
+workerpool@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.3.0.tgz#86c5cbe946b55e7dc9d12b1936c8801a6e2d744d"
   dependencies:
     object-assign "4.1.1"
 


### PR DESCRIPTION
Prior to this change, there was a fundamental misunderstanding of the way the forms portion of the definition is meant to be used. Because of this we were unable to support deterministic ordering and grouping.

This change is a complete rewrite of the schema parsing which will support the correct format while keeping backwards compatibility (deprecated).

https://github.com/json-schema-form/json-schema-form/wiki/Documentation