### PR TITLE
Make onUpdate validation opt-in

### DIFF
--- a/addon/components/kinetic-form.js
+++ b/addon/components/kinetic-form.js
@@ -134,6 +134,10 @@ export default Component.extend({
     });
   },
 
+  notifyUpdate() {
+    get(this, 'onUpdate')(get(this, 'changeset'));
+  },
+
   init() {
     this._super(...arguments);
     set(this, '_updatedFields', A());
@@ -149,7 +153,7 @@ export default Component.extend({
         get(this, '_updatedFields').pushObject(key);
         debounce(this, this.validateAndNotifyUpdate, delay);
       } else {
-        get(this, 'onUpdate')(get(this, 'changeset'));
+        debounce(this, this.notifyUpdate, delay); 
       }
     },
 

--- a/addon/components/kinetic-form.js
+++ b/addon/components/kinetic-form.js
@@ -29,6 +29,7 @@ export default Component.extend({
 
   showErrors: false,
   updateDebounceDelay: DEFAULT_UPDATE_DEBOUNCE_DELAY,
+  validateOnUpdate: false,
 
   loadingComponent: 'kinetic-form/loading',
   errorComponent: 'kinetic-form/errors',
@@ -143,8 +144,13 @@ export default Component.extend({
       set(this, `changeset.${key}`, value);
       if (!get(this, 'onUpdate')) { return; }
       let delay = get(this, 'updateDebounceDelay');
-      get(this, '_updatedFields').pushObject(key);
-      debounce(this, this.validateAndNotifyUpdate, delay);
+      let validate = get(this, 'validateOnUpdate');
+      if (validate) { 
+        get(this, '_updatedFields').pushObject(key);
+        debounce(this, this.validateAndNotifyUpdate, delay);
+      } else {
+        get(this, 'onUpdate')(get(this, 'changeset'));
+      }
     },
 
     submit() {

--- a/tests/dummy/app/controllers/kinetic-form.js
+++ b/tests/dummy/app/controllers/kinetic-form.js
@@ -10,6 +10,9 @@ export default Controller.extend({
   actions: {
     sendToServer() {
       alert('fake sent');
+    },
+    update() {
+      console.log('update fired');
     }
   }
 });

--- a/tests/dummy/app/controllers/semantic-ui-kinetic-form.js
+++ b/tests/dummy/app/controllers/semantic-ui-kinetic-form.js
@@ -10,6 +10,9 @@ export default Controller.extend({
   actions: {
     sendToServer() {
       alert('fake sent');
+    },
+    update() {
+      console.log('update fired');
     }
   }
 });

--- a/tests/dummy/app/templates/kinetic-form.hbs
+++ b/tests/dummy/app/templates/kinetic-form.hbs
@@ -1,4 +1,5 @@
 {{kinetic-form
     definition=sampleDefinition
     model=sampleModel
+    onUpdate=(action "update")
     onSubmit=(action "sendToServer")}}

--- a/tests/dummy/app/templates/semantic-ui-kinetic-form.hbs
+++ b/tests/dummy/app/templates/semantic-ui-kinetic-form.hbs
@@ -1,4 +1,5 @@
 {{semantic-ui-kinetic-form
     definition=sampleDefinition
     model=sampleModel
+    onUpdate=(action "update")
     onSubmit=(action "sendToServer")}}


### PR DESCRIPTION
@sukima @utilityboy 

Allow for declaring whether or not validations are run on update

**Use case**: Someone accidentally clicks on a checkbox (required) and document saves. User un-checks the input which updates the ui state but the document cannot be saved as the validation fails.