### PR TITLE
Guard against empty schema/form values

### DIFF
--- a/addon/components/kinetic-form.js
+++ b/addon/components/kinetic-form.js
@@ -90,7 +90,17 @@ export default Component.extend({
       };
       let schema = get(this, 'decoratedDefinition.schema') || {};
       let form = A(get(this, 'decoratedDefinition.form') || []);
-      return SchemaFormParser.create({ schema, form, lookupComponentName });
+      let existingSchemaParser = get(this, '_schemaParser');
+
+      if (existingSchemaParser && !Object.keys(schema).length && !form.length) {
+        return existingSchemaParser;
+      }
+
+      let schemaFormParser = SchemaFormParser.create({ schema, form, lookupComponentName });
+
+      set(this, '_schemaParser', schemaFormParser);
+
+      return schemaFormParser;
     }
   }),
 


### PR DESCRIPTION
@sukima @utilityboy 

`schema` and `form` values in the `schemaParser` computed would be null after autosaving the form. This would cause an assertion error in `-schema-form-parser` as it expects schema to have a property `type` with a value of `object`.

To guard against this we return the original `SchemaFormParser` if it exists and the values for `schema` and `form` are empty.

```js
schemaParser: computed('decoratedDefinition.{schema,form}', {
    get() {
      const lookupComponentName = type => {
        return get(this, `${type}Component`) || get(this, DEFAULT_COMPONENT_NAME_PROP);
      };
      let schema = get(this, 'decoratedDefinition.schema') || {};
      let form = A(get(this, 'decoratedDefinition.form') || []);
      let existingSchemaParser = get(this, '_schemaParser');

      if (existingSchemaParser && !Object.keys(schema).length && !form.length) {
        return existingSchemaParser;
      }

      let schemaFormParser = SchemaFormParser.create({ schema, form, lookupComponentName });

      set(this, '_schemaParser', schemaFormParser);

      return schemaFormParser;
    }
  }),
```

@sukima, do you know why `decoratedDefinition.schema/form` would be defined on first load but would be undefined after auto saving the form?



