### PR TITLE
Introduce the notion of `readOnly`

### DIFF
--- a/addon/components/kinetic-form.js
+++ b/addon/components/kinetic-form.js
@@ -29,6 +29,7 @@ export default Component.extend({
   classNames: ['kinetic-form'],
 
   showErrors: false,
+  readOnly: false,
   updateDebounceDelay: DEFAULT_UPDATE_DEBOUNCE_DELAY,
 
   loadingComponent: 'kinetic-form/loading',
@@ -158,6 +159,7 @@ export default Component.extend({
 
   actions: {
     updateProperty(key, value, validate = true) {
+      if (get(this, 'readOnly')) return;
       set(this, `changeset.${key}`, value);
       // HACK: ember-changeset will not set a property that is not valid. This is causing some bogus ui state so we need to manually set the property
       // https://github.com/poteto/ember-changeset/blob/353d0e5822efca3104a2b147e47608bc0176e440/addon/index.js#L650
@@ -179,6 +181,7 @@ export default Component.extend({
     },
 
     submit(validate = true) {
+      if (get(this, 'readOnly')) return;
       if (validate) {
         return this.validateAndNotifySubmit();
       } else {

--- a/addon/templates/components/kinetic-form.hbs
+++ b/addon/templates/components/kinetic-form.hbs
@@ -5,10 +5,30 @@
 {{#if decoratedDefinition.isPending}}
   {{component loadingComponent}}
 {{else}}
-  {{#component formComponent changeset=changeset title=decoratedDefinition.schema.title isInvalid=changeset.isInvalid onSubmit=(action "submit")}}
+  {{#component formComponent 
+    changeset=changeset 
+    title=decoratedDefinition.schema.title 
+    isInvalid=changeset.isInvalid 
+    onSubmit=(action "submit")
+    readOnly=readOnly
+  }}
     {{#each properties as |field|}}
-      {{#component field.componentName field=field changeset=changeset error=(get changeset.error field.key) value=(get changeset field.key) update=(action "updateProperty" field.key) as |item|}}
-        {{component item.componentName field=item error=(get changeset.error item.key) value=(get changeset item.key) update=(action "updateProperty" item.key)}}
+      {{#component 
+        field.componentName 
+        field=field 
+        changeset=changeset 
+        error=(get changeset.error field.key) 
+        value=(get changeset field.key) 
+        update=(action "updateProperty" 
+        field.key) as |item|
+      }}
+        {{component 
+          item.componentName 
+          field=item 
+          error=(get changeset.error item.key) 
+          value=(get changeset item.key) 
+          update=(action "updateProperty" item.key)
+        }}
       {{/component}}
     {{/each}}
   {{/component}}

--- a/addon/templates/components/kinetic-form/form.hbs
+++ b/addon/templates/components/kinetic-form/form.hbs
@@ -2,6 +2,8 @@
 
 {{yield}}
 
-<fieldset>
-  <button type="submit" disabled={{isInvalid}}>Submit</button>
-</fieldset>
+{{#unless readOnly}}
+  <fieldset>
+    <button type="submit" disabled={{isInvalid}}>Submit</button>
+  </fieldset>
+{{/unless}}

--- a/addon/templates/components/semantic-ui-kinetic-form/form.hbs
+++ b/addon/templates/components/semantic-ui-kinetic-form/form.hbs
@@ -4,6 +4,8 @@
   {{yield}}
 </div>
 
-<div class="actions">
-  <button class="ui positive huge button" type="submit" disabled={{isInvalid}}>Submit</button>
-</div>
+{{#unless readOnly}}
+  <div class="actions">
+    <button class="ui positive huge button" type="submit" disabled={{isInvalid}}>Submit</button>
+  </div>
+{{/unless}}


### PR DESCRIPTION
@utilityboy 

- Passing `readOnly` true to kinetic form will remove the submit button and prevent any mutations to the form inputs