### PR TITLE
Refactor validation and debouncing

### DIFF
--- a/addon/components/kinetic-form.js
+++ b/addon/components/kinetic-form.js
@@ -111,33 +111,14 @@ export default Component.extend({
 
   validateAndNotifySubmit() {
     return this.validateForm().then(isValid => {
-      if (!isValid) {
-        return;
-      }
+      if (!isValid) return;
       get(this, 'onSubmit')(get(this, 'changeset'), true);
     });
   },
 
-  validateAndNotifyUpdate() {
-    if (this.isDestroyed) {
-      return;
-    }
-    let updatedFields = get(this, '_updatedFields');
-    let validations = updatedFields.uniq().map(field => this.validateForm(field));
-    updatedFields.clear();
-    return all(validations).then(validationResults => {
-      let isValid = validationResults.every(identity => identity);
-      if (!isValid) {
-        return;
-      }
-      return get(this, 'onUpdate')(get(this, 'changeset'), true);
-    });
-  },
-
-  notifyUpdate() {
-    if (this.isDestroyed) {
-      return;
-    }
+  notifyUpdate(key) {
+    if (this.isDestroyed) return;
+    get(this, 'changeset').validate();
     get(this, 'onUpdate')(get(this, 'changeset'));
   },
 

--- a/addon/components/kinetic-form.js
+++ b/addon/components/kinetic-form.js
@@ -61,6 +61,7 @@ export default Component.extend({
       let model = get(this, 'model');
       let validations = get(this, 'validators');
       let changeset = new Changeset(model, lookupValidator(validations), validations);
+      if (Object.keys(model).length) changeset.validate();
       return changeset;
     }
   }),


### PR DESCRIPTION
@utilityboy 

- Debouncing needs to be the responsibility of the `onUpdate` parameter otherwise we run into race conditions when data is in flight.
- Changeset validations needs to be run on all input updates otherwise we get incorrect ui state for disabling the complete/submit button