### PR TITLE
[ENG-3444] Add virtual keyboard support

### DIFF
--- a/addon/templates/components/kinetic-form/number.hbs
+++ b/addon/templates/components/kinetic-form/number.hbs
@@ -2,8 +2,4 @@
   {{field.title}}
   {{#if field.required}}*{{/if}}
 </label>
-<input
-    type="number"
-    value={{value}}
-    onchange={{action update value="target.value"}}
-    oninput={{action update value="target.value"}}>
+{{input type="number" value=value}}

--- a/addon/templates/components/kinetic-form/string.hbs
+++ b/addon/templates/components/kinetic-form/string.hbs
@@ -2,8 +2,4 @@
   {{field.title}}
   {{#if field.required}}*{{/if}}
 </label>
-<input
-    type="text"
-    value={{value}}
-    onchange={{action update value="target.value"}}
-    oninput={{action update value="target.value"}}>
+{{input type="text" value=value}}

--- a/addon/templates/components/semantic-ui-kinetic-form/number.hbs
+++ b/addon/templates/components/semantic-ui-kinetic-form/number.hbs
@@ -1,10 +1,6 @@
 <div class="middle aligned content">
   <div class="field {{if error 'error'}} {{if field.required 'required'}}">
     <label>{{field.title}}</label>
-    <input
-        type="number"
-        value={{value}}
-        onchange={{action update value="target.value"}}
-        oninput={{action update value="target.value"}}>
+    {{input type="number" value=value}}
   </div>
 </div>

--- a/addon/templates/components/semantic-ui-kinetic-form/string.hbs
+++ b/addon/templates/components/semantic-ui-kinetic-form/string.hbs
@@ -1,10 +1,6 @@
 <div class="middle aligned content">
   <div class="field {{if error 'error'}} {{if field.required 'required'}}">
     <label>{{field.title}}</label>
-    <input
-        type="text"
-        value={{value}}
-        onchange={{action update value="target.value"}}
-        oninput={{action update value="target.value"}}>
+    {{input type="text" value=value}}
   </div>
 </div>

--- a/addon/templates/components/semantic-ui-kinetic-form/textarea.hbs
+++ b/addon/templates/components/semantic-ui-kinetic-form/textarea.hbs
@@ -1,6 +1,6 @@
 <div class="middle aligned content">
   <div class="field {{if error 'error'}} {{if field.required 'required'}}">
     <label>{{field.title}}</label>
-    <textarea rows=4 onchange={{action update value="target.value"}} oninput={{action update value="target.value"}}>{{value}}</textarea>
+    {{textarea rows=4 value=value}}
   </div>
 </div>


### PR DESCRIPTION
@utilityboy for the virtual keyboard to work we need to use Ember's input/textarea helpers. All of the logic/event bindings are done by extending those components so bare `<input>`s will not work.

Without this change, users will not be able to fill out safety or checklists when logging in.

Here are the current versions of `ember-kinetic-form` we use across our repos:
- `lmv-collab`: "ember-kinetic-form": "https://github.com/funnelcloudinc/ember-kinetic-form.git#v1.0.1",
- `funnel-core`: "ember-kinetic-form": "https://github.com/funnelcloudinc/ember-kinetic-form.git#v0.4.0",
  - When developing locally I was working off of develop (1.0.1) some very slight changes were needed in the operator terminal  
- `app-maintenance`: "ember-kinetic-form": "https://github.com/funnelcloudinc/ember-kinetic-form.git#v1.0.0",

As far as I can tell so far there seem to be no issues swapping out bare `<input>`s for `{{input}}`s. 