### PR TITLE
[ENG-4164] Port new control types

### DIFF
--- a/addon/components/kinetic-form.js
+++ b/addon/components/kinetic-form.js
@@ -34,6 +34,7 @@ export default Component.extend({
   sectionComponent: 'kinetic-form/section',
   passfailComponent: 'kinetic-form/passfail',
   instructionsComponent: 'kinetic-form/instructions',
+  multiplechoiceComponent: 'kinetic-form/multiplechoice',
 
   properties: reads('schemaParser.elements'),
 

--- a/addon/components/kinetic-form.js
+++ b/addon/components/kinetic-form.js
@@ -33,6 +33,7 @@ export default Component.extend({
   selectComponent: 'kinetic-form/select',
   sectionComponent: 'kinetic-form/section',
   passfailComponent: 'kinetic-form/passfail',
+  instructionsComponent: 'kinetic-form/instructions',
 
   properties: reads('schemaParser.elements'),
 

--- a/addon/components/kinetic-form.js
+++ b/addon/components/kinetic-form.js
@@ -32,6 +32,7 @@ export default Component.extend({
   textareaComponent: 'kinetic-form/textarea',
   selectComponent: 'kinetic-form/select',
   sectionComponent: 'kinetic-form/section',
+  passfailComponent: 'kinetic-form/passfail',
 
   properties: reads('schemaParser.elements'),
 

--- a/addon/components/kinetic-form/instructions.js
+++ b/addon/components/kinetic-form/instructions.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import layout from '../../templates/components/kinetic-form/instructions';
+
+export default Ember.Component.extend({
+  layout,
+  tagName: 'fieldset',
+  classNames: ['kinetic-form--instructions']
+});

--- a/addon/components/kinetic-form/multiplechoice.js
+++ b/addon/components/kinetic-form/multiplechoice.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+import layout from '../../templates/components/kinetic-form/multiplechoice';
+
+const { Component, get, set } = Ember;
+
+export default Component.extend({
+  layout,
+  tagName: 'fieldset',
+  classNames: ['kinetic-form--multiplechoice'],
+  classNameBindings: ['error:has-error'],
+
+  init() {
+    this._super(...arguments);
+    const value = get(this, 'value')
+
+    if (!value) {
+      const numberOfChoices = get(this, 'field.multiple_choice_options.length');
+      const initialValue = Array(numberOfChoices).fill(false);
+  
+      set(this, 'workingValue', initialValue);
+    } else {
+      set(this, 'workingValue', [...value]);
+    }
+  },
+
+  actions: {
+    updateChoice(index) {
+      let updatedValue;
+      const choices = get(this, 'workingValue');
+
+      if (get(this, 'field.allow_multiple_choice')) {
+        updatedValue = [...choices];  
+      } else {
+        const numberOfChoices = get(this, 'field.multiple_choice_options.length');
+
+        updatedValue = Array(numberOfChoices).fill(false);
+      }
+
+      updatedValue.replace(index, 1, [ !choices[index] ]);
+
+      set(this, 'workingValue', [...updatedValue]);
+
+      if (updatedValue.every(a => !a)) {
+        // Reset to no input if no answers are selected.
+        get(this, 'update')('');  
+      } else {
+        get(this, 'update')(updatedValue);
+      }
+    }
+  }
+});

--- a/addon/components/kinetic-form/passfail.js
+++ b/addon/components/kinetic-form/passfail.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import layout from '../../templates/components/kinetic-form/passfail';
+
+export default Ember.Component.extend({
+  layout,
+  tagName: 'fieldset',
+  classNames: ['kinetic-form--passfail'],
+  classNameBindings: ['error:has-error'],
+});

--- a/addon/components/semantic-ui-kinetic-form.js
+++ b/addon/components/semantic-ui-kinetic-form.js
@@ -12,5 +12,6 @@ export default KineticFormComponent.extend({
   radiosComponent: 'semantic-ui-kinetic-form/radios',
   textareaComponent: 'semantic-ui-kinetic-form/textarea',
   selectComponent: 'semantic-ui-kinetic-form/select',
-  sectionComponent: 'kinetic-form/section'
+  sectionComponent: 'kinetic-form/section',
+  passfailComponent: 'semantic-ui-kinetic-form/passfail',
 });

--- a/addon/components/semantic-ui-kinetic-form.js
+++ b/addon/components/semantic-ui-kinetic-form.js
@@ -14,4 +14,5 @@ export default KineticFormComponent.extend({
   selectComponent: 'semantic-ui-kinetic-form/select',
   sectionComponent: 'kinetic-form/section',
   passfailComponent: 'semantic-ui-kinetic-form/passfail',
+  instructionsComponent: 'semantic-ui-kinetic-form/instructions',
 });

--- a/addon/components/semantic-ui-kinetic-form.js
+++ b/addon/components/semantic-ui-kinetic-form.js
@@ -15,4 +15,5 @@ export default KineticFormComponent.extend({
   sectionComponent: 'kinetic-form/section',
   passfailComponent: 'semantic-ui-kinetic-form/passfail',
   instructionsComponent: 'semantic-ui-kinetic-form/instructions',
+  multiplechoiceComponent: 'semantic-ui-kinetic-form/multiplechoice',
 });

--- a/addon/components/semantic-ui-kinetic-form/instructions.js
+++ b/addon/components/semantic-ui-kinetic-form/instructions.js
@@ -1,0 +1,7 @@
+import KineticFormInstructionsComponent from '../kinetic-form/instructions';
+import layout from '../../templates/components/semantic-ui-kinetic-form/instructions';
+
+export default KineticFormInstructionsComponent.extend({
+  layout,
+  classNames: ['semantic-ui-kinetic-form--instructions', 'item']
+});

--- a/addon/components/semantic-ui-kinetic-form/multiplechoice.js
+++ b/addon/components/semantic-ui-kinetic-form/multiplechoice.js
@@ -1,0 +1,7 @@
+import KineticMultipleChoiceInstructionsComponent from '../kinetic-form/multiplechoice';
+import layout from '../../templates/components/semantic-ui-kinetic-form/multiplechoice';
+
+export default KineticMultipleChoiceInstructionsComponent.extend({
+  layout,
+  classNames: ['semantic-ui-kinetic-form--multiplechoice', 'item']
+});

--- a/addon/components/semantic-ui-kinetic-form/passfail.js
+++ b/addon/components/semantic-ui-kinetic-form/passfail.js
@@ -1,0 +1,7 @@
+import KineticFormPassFailComponent from '../kinetic-form/passfail';
+import layout from '../../templates/components/semantic-ui-kinetic-form/passfail';
+
+export default KineticFormPassFailComponent.extend({
+  layout,
+  classNames: ['semantic-ui-kinetic-form--passfail', 'item'],
+});

--- a/addon/templates/components/kinetic-form/instructions.hbs
+++ b/addon/templates/components/kinetic-form/instructions.hbs
@@ -1,0 +1,1 @@
+<div>{{field.title}}</div>

--- a/addon/templates/components/kinetic-form/multiplechoice.hbs
+++ b/addon/templates/components/kinetic-form/multiplechoice.hbs
@@ -1,0 +1,20 @@
+<div>
+  <div>
+    <label>{{field.title}}</label>
+    <div>
+      <div>
+        <div>
+          {{if field.allow_multiple_choice 'Select Multiple Choices' 'Select Single Choice'}}
+        </div>
+        {{#each field.multiple_choice_options as |option index|}}
+          <div onClick={{action 'updateChoice' index}}>
+            <label>
+              <input type="checkbox" checked={{object-at index value}}>
+              {{option}}
+            </label>
+          </div>
+        {{/each}}
+      </div>
+    </div>
+  </div>
+</div>

--- a/addon/templates/components/kinetic-form/passfail.hbs
+++ b/addon/templates/components/kinetic-form/passfail.hbs
@@ -1,0 +1,21 @@
+<div>
+  <div>
+    <label>{{field.title}}</label>
+    <div>
+      <label>
+        <input
+          type="radio"
+          checked={{eq value true}}
+          onclick={{action update true}}>
+        Pass
+      </label>
+      <label>
+        <input
+          type="radio"
+          checked={{eq value false}}
+          onclick={{action update false}}>
+        Fail
+      </label>
+    </div>
+  </div>
+</div>

--- a/addon/templates/components/semantic-ui-kinetic-form/instructions.hbs
+++ b/addon/templates/components/semantic-ui-kinetic-form/instructions.hbs
@@ -1,0 +1,5 @@
+<div class="middle aligned content">
+  <div class="field">
+    <div style="white-space: pre-line">{{field.title}}</div>
+  </div>
+</div>

--- a/addon/templates/components/semantic-ui-kinetic-form/multiplechoice.hbs
+++ b/addon/templates/components/semantic-ui-kinetic-form/multiplechoice.hbs
@@ -1,0 +1,22 @@
+<div class="middle aligned content">
+  <div class="field {{if error 'error'}} {{if field.required 'required'}}">
+    <label>{{field.title}}</label>
+    <div class="ui form">
+      <div class="ui segments">
+        <div class="ui segment info message">
+          {{t (if field.allow_multiple_choice 'selectMultipleChoices' 'selectSingleChoice')}}
+        </div>
+        {{#each field.multiple_choice_options as |option index|}}
+          <div class="ui {{if (object-at index value) 'secondary'}} segment" onClick={{action 'updateChoice' index}}>
+            <label>
+              <i class="blue large {{if field.allow_multiple_choice 'square' 'circle'}} 
+                {{unless (object-at index value) 'grey outline'}} icon">
+              </i>
+              {{option}}
+            </label>
+          </div>
+        {{/each}}
+      </div>
+    </div>
+  </div>
+</div>

--- a/addon/templates/components/semantic-ui-kinetic-form/passfail.hbs
+++ b/addon/templates/components/semantic-ui-kinetic-form/passfail.hbs
@@ -1,0 +1,13 @@
+<div class="middle aligned content">
+  <div class="field {{if error 'error'}} {{if field.required 'required'}}">
+    <label>{{field.title}}</label>
+    <div class="ui big fluid basic icon buttons">
+      <div class="ui {{if (eq value true) 'active'}} button" {{action update true}}>
+        <i class="{{if (eq value true) 'green'}} check icon big"></i>
+      </div>
+      <div class="ui {{if (eq value false) 'active'}} button" {{action update false}}>
+        <i class="{{if (eq value false) 'red'}} close icon big"></i>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/kinetic-form/instructions.js
+++ b/app/components/kinetic-form/instructions.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-kinetic-form/components/kinetic-form/instructions';

--- a/app/components/kinetic-form/multiplechoice.js
+++ b/app/components/kinetic-form/multiplechoice.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-kinetic-form/components/kinetic-form/multiplechoice';

--- a/app/components/kinetic-form/passfail.js
+++ b/app/components/kinetic-form/passfail.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-kinetic-form/components/kinetic-form/passfail';

--- a/app/components/semantic-ui-kinetic-form/instructions.js
+++ b/app/components/semantic-ui-kinetic-form/instructions.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-kinetic-form/components/semantic-ui-kinetic-form/instructions';

--- a/app/components/semantic-ui-kinetic-form/multiplechoice.js
+++ b/app/components/semantic-ui-kinetic-form/multiplechoice.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-kinetic-form/components/semantic-ui-kinetic-form/multiplechoice';

--- a/app/components/semantic-ui-kinetic-form/passfail.js
+++ b/app/components/semantic-ui-kinetic-form/passfail.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-kinetic-form/components/semantic-ui-kinetic-form/passfail';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-kinetic-form",
-  "version": "0.4.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3545,6 +3545,16 @@
         }
       }
     },
+    "ember-composable-helpers": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-2.1.0.tgz",
+      "integrity": "sha512-H6KCyB/BzjR18MxQFcQQR5MDRmawCmCCZKHQTEpAwhs5wCDhnMMLUGINan+sY4NRPrStfpUlMoGg9fsksN2wJA==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "^1.0.1",
+        "ember-cli-babel": "^6.6.0"
+      }
+    },
     "ember-concurrency": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-1.0.0.tgz",
@@ -4688,6 +4698,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-2.1.0.tgz",
       "integrity": "sha512-BQlU8aTNl1XHKTYZ243r66yqtR9JU7XKWQcmMA+vkqfkE/c9WWQ9hQZM8YABihCmbyxzzZsngvldokmeX5GhAw==",
+      "dev": true,
       "requires": {
         "ember-cli-babel": "^6.6.0"
       }
@@ -5670,7 +5681,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -5721,7 +5733,8 @@
         "balanced-match": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -5736,6 +5749,7 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -5744,6 +5758,7 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -5752,6 +5767,7 @@
           "version": "1.1.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
@@ -5760,7 +5776,8 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -5777,12 +5794,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -5790,22 +5809,26 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -5845,7 +5868,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -5877,7 +5901,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -5899,12 +5924,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -5960,6 +5987,7 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -5972,7 +6000,8 @@
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -6000,6 +6029,7 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -6010,7 +6040,8 @@
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -6027,6 +6058,7 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -6035,7 +6067,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -6047,6 +6080,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6060,7 +6094,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -6133,12 +6168,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -6147,6 +6184,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6154,12 +6192,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6214,7 +6254,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -6232,6 +6273,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6261,7 +6303,8 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -6272,7 +6315,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -6310,6 +6354,7 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -6354,6 +6399,7 @@
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -6361,7 +6407,8 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -6385,6 +6432,7 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -6418,6 +6466,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6428,6 +6477,7 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -6442,6 +6492,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6456,6 +6507,7 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -6511,7 +6563,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -6540,7 +6593,8 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-composable-helpers": "2.1.0",
     "ember-concurrency": "^1.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",

--- a/tests/dummy/app/helpers/t.js
+++ b/tests/dummy/app/helpers/t.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function t(params/*, hash*/) {
+  return `${params[0]}`;
+}
+
+export default Ember.Helper.helper(t);

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -24,6 +24,32 @@ export default Route.extend({
           '4': {
             type: 'boolean',
             title: 'frotz'
+          },
+          '5': {
+            type: 'select',
+            title: 'Select one',
+            options: [
+              'jam',
+              'honey'
+            ]
+          },
+          '6': {
+            type: 'passfail',
+            title: 'Pass or fail'
+          },
+          '7': {
+            type: 'instructions',
+            title: 'Here are my instructions'
+          },
+          '8': {
+            type: 'multiplechoice',
+            title: 'Choose many',
+            multiple_choice_options: [
+              'Happy',
+              'Sad',
+              "Undecided"
+            ],
+            allow_multiple_choice: true
           }
         }
       },
@@ -33,7 +59,7 @@ export default Route.extend({
         {
           type: 'section',
           title: 'Section 1',
-          items: [{ key: '2', type: 'radio' }, '1']
+          items: [{ key: '2', type: 'radio' }, '1','5','6','7','8']
         }
       ]
     };


### PR DESCRIPTION
# ENG-4164

## Change Description
- implements the `passfail`, `instructions`, and `multiplechoice` custom control types
- adds examples of the new types to the dummy app
- mocks the `t` helper in the dummy app

## Related PRs
- https://github.com/funnelcloudinc/lmv-collab/pull/1989
- https://github.com/funnelcloudinc/app-maintenance/pull/209
- https://github.com/funnelcloudinc/funnel-site/pull/376

## PR Readiness Checklist
- [x] I have the correct title format `[ENG-xxx] Short Description for Readers`
- [x] I have confirmed the correct base branch
- [x] I have filled in the PR description and added any necessary annotations
- [x] I have included only functional changes represented by the Jira ticket
- [x] I have tested the code locally or an equivalent environment using the UI if possible
- [x] I have ensured unit tests are green in CI or locally if CI is unavailable
- [x] I have run any applicable formatters
- [x] I have specified any dependencies on other repos/branches/tickets/PRs
- [x] I have updated the Jira ticket with sufficient information and testing instructions for Reviewer/QA/Ops
- [x] I have validated this change does not destroy customer data
- [x] I have moved the associated ticket to `Code Review` if applicable