### PR TITLE
[ENG-5484] [ADMIN] Extend ember-kinetic-form to support sub-sections - release/v1

### DIFF
--- a/addon/-schema-form-parser.js
+++ b/addon/-schema-form-parser.js
@@ -29,9 +29,18 @@ export function normalizeFormElement(element, properties, requiredKeys, lookup) 
 export function* normalizeFormElements(form, properties, requiredKeys, lookup) {
   function* mapProperties(items) {
     for (let item of items) {
-      let element = typeOf(item) === 'string' ? { key: item } : item;
-      yield normalizeFormElement(element, properties, requiredKeys, lookup);
-      if (element.key) { propertiesAccountedFor[element.key] = true; }
+      // Identifies the non-base cases,
+      // i.e. non-empty sections with items that still need to be processed
+      if (item.items && (item.items[0] && !item.items[0].componentName)) {
+        let recItems = [...mapProperties(item.items)];
+        yield* mapProperties([Object.assign({}, item, { items: recItems })]);  
+      } else {
+        let element = typeOf(item) === 'string' ? { key: item } : item;
+        yield normalizeFormElement(element, properties, requiredKeys, lookup);
+        if (element.key) {
+          propertiesAccountedFor[element.key] = true;
+        }  
+      }
     }
   }
   let propertiesAccountedFor = {};

--- a/addon/templates/components/kinetic-form.hbs
+++ b/addon/templates/components/kinetic-form.hbs
@@ -14,23 +14,14 @@
     readOnly=readOnly
   }}
     {{#each properties as |field|}}
-      {{#component 
+      {{component 
         field.componentName 
         field=field 
         changeset=changeset 
         error=(get changeset.error field.key) 
         value=(get changeset field.key) 
-        update=(action "updateProperty" 
-        field.key) as |item|
+        update=(action "updateProperty" field.key)
       }}
-        {{component 
-          item.componentName 
-          field=item 
-          error=(get changeset.error item.key) 
-          value=(get changeset item.key) 
-          update=(action "updateProperty" item.key)
-        }}
-      {{/component}}
     {{/each}}
   {{/component}}
 {{/if}}

--- a/addon/templates/components/kinetic-form.hbs
+++ b/addon/templates/components/kinetic-form.hbs
@@ -21,6 +21,7 @@
         error=(get changeset.error field.key) 
         value=(get changeset field.key) 
         update=(action "updateProperty" field.key)
+        updateAction=(action "updateProperty")
       }}
     {{/each}}
   {{/component}}

--- a/addon/templates/components/kinetic-form/section.hbs
+++ b/addon/templates/components/kinetic-form/section.hbs
@@ -3,9 +3,11 @@
 {{#each field.items as |item|}}
   {{component 
     item.componentName 
-    field=item 
+    field=item
+    changeset=changeset
+    updateAction=updateAction
     error=(get changeset.error item.key) 
     value=(get changeset item.key) 
-    update=(action update item.key)
+    update=(action updateAction item.key)
   }}
 {{/each}}

--- a/addon/templates/components/kinetic-form/section.hbs
+++ b/addon/templates/components/kinetic-form/section.hbs
@@ -1,5 +1,11 @@
 <h2 id={{anchor}}>{{field.title}}</h2>
 
 {{#each field.items as |item|}}
-  {{yield item}}
+  {{component 
+    item.componentName 
+    field=item 
+    error=(get changeset.error item.key) 
+    value=(get changeset item.key) 
+    update=(action update item.key)
+  }}
 {{/each}}

--- a/addon/templates/components/semantic-ui-kinetic-form/section.hbs
+++ b/addon/templates/components/semantic-ui-kinetic-form/section.hbs
@@ -5,9 +5,11 @@
 {{#each field.items as |item|}}
   {{component 
     item.componentName 
-    field=item 
+    field=item
+    changeset=changeset
+    updateAction=updateAction
     error=(get changeset.error item.key) 
     value=(get changeset item.key) 
-    update=(action update item.key)
+    update=(action updateAction item.key)
   }}
 {{/each}}

--- a/addon/templates/components/semantic-ui-kinetic-form/section.hbs
+++ b/addon/templates/components/semantic-ui-kinetic-form/section.hbs
@@ -3,5 +3,11 @@
 </h2>
 
 {{#each field.items as |item|}}
-  {{yield item}}
+  {{component 
+    item.componentName 
+    field=item 
+    error=(get changeset.error item.key) 
+    value=(get changeset item.key) 
+    update=(action update item.key)
+  }}
 {{/each}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1873,15 +1873,6 @@
         }
       }
     },
-    "broccoli-unwatched-tree": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/broccoli-unwatched-tree/-/broccoli-unwatched-tree-0.1.3.tgz",
-      "integrity": "sha1-qw+4IPYThFv2eoA7qtgg9oseOq4=",
-      "dev": true,
-      "requires": {
-        "broccoli-source": "^1.1.0"
-      }
-    },
     "broccoli-writer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
@@ -2019,7 +2010,7 @@
     "ceibo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ceibo/-/ceibo-2.0.0.tgz",
-      "integrity": "sha1-mmHrBUqRwJk0WI1ORdndLDvwTu4=",
+      "integrity": "sha512-Zt+Nhkzd1s9hsOhEmCMkmzAn1AmjQ/RuEnXOF3H46NYlkrQoApA8PIiacz/YASdxeFse1F50B7eoppw4pPie6g==",
       "dev": true
     },
     "center-align": {
@@ -3140,14 +3131,14 @@
       "dev": true
     },
     "ember-cli-node-assets": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ember-cli-node-assets/-/ember-cli-node-assets-0.1.6.tgz",
-      "integrity": "sha1-ZIiilJBIyAGtbZ4zdTx7zjL8EUY=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz",
+      "integrity": "sha512-pFyjlhzwx2FxAmkxSVJvP+i+MwHDhmgsmma1ZQbFLYwBeufo1GIzqSJUfStcpOE1NDg8fXm2yZVVzdZYf9lW2w==",
       "dev": true,
       "requires": {
         "broccoli-funnel": "^1.0.1",
         "broccoli-merge-trees": "^1.1.1",
-        "broccoli-unwatched-tree": "^0.1.1",
+        "broccoli-source": "^1.1.0",
         "debug": "^2.2.0",
         "lodash": "^4.5.1",
         "resolve": "^1.1.7"
@@ -3163,228 +3154,215 @@
       }
     },
     "ember-cli-page-object": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-page-object/-/ember-cli-page-object-1.12.1.tgz",
-      "integrity": "sha512-VzliZZJCRJSt5pXPYN8WfwA29SM/AeRg1Yh9W6ZjTY261IKw7Ij12P+fOFNKIiT5x/DAn01ZdMnmhnWzCJUQ0g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-page-object/-/ember-cli-page-object-1.16.2.tgz",
+      "integrity": "sha512-1ce495Tp6R5P1FnXYGvfHDe+QtkRwz5RzcxiO9qNSUN7j13iSo6vbiB/12t3nNNOIW/k/BshsQHgD83L7xZOpw==",
       "dev": true,
       "requires": {
+        "broccoli-file-creator": "^2.1.1",
+        "broccoli-merge-trees": "^2.0.0",
         "ceibo": "~2.0.0",
-        "ember-cli-babel": "^5.1.7",
-        "ember-cli-get-component-path-option": "^1.0.0",
-        "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cli-node-assets": "^0.1.2",
-        "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-path-utils": "^1.0.0",
-        "ember-cli-string-utils": "^1.0.0",
-        "ember-cli-test-info": "^1.0.0",
-        "ember-cli-valid-component-name": "^1.0.0",
-        "ember-cli-version-checker": "^1.2.0",
-        "ember-test-helpers": "^0.6.3",
-        "rsvp": "^3.2.1"
+        "ember-cli-babel": "^6.16.0",
+        "ember-cli-node-assets": "^0.2.2",
+        "ember-native-dom-helpers": "^0.6.3",
+        "jquery": "^3.2.1",
+        "rsvp": "^4.7.0"
       },
       "dependencies": {
-        "babel-core": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
+        "amd-name-resolver": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
+          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
           "dev": true,
           "requires": {
-            "babel-plugin-constant-folding": "^1.0.1",
-            "babel-plugin-dead-code-elimination": "^1.0.2",
-            "babel-plugin-eval": "^1.0.1",
-            "babel-plugin-inline-environment-variables": "^1.0.1",
-            "babel-plugin-jscript": "^1.0.4",
-            "babel-plugin-member-expression-literals": "^1.0.1",
-            "babel-plugin-property-literals": "^1.0.1",
-            "babel-plugin-proto-to-assign": "^1.0.3",
-            "babel-plugin-react-constant-elements": "^1.0.3",
-            "babel-plugin-react-display-name": "^1.0.3",
-            "babel-plugin-remove-console": "^1.0.1",
-            "babel-plugin-remove-debugger": "^1.0.1",
-            "babel-plugin-runtime": "^1.0.7",
-            "babel-plugin-undeclared-variables-check": "^1.0.2",
-            "babel-plugin-undefined-to-void": "^1.1.6",
-            "babylon": "^5.8.38",
-            "bluebird": "^2.9.33",
-            "chalk": "^1.0.0",
-            "convert-source-map": "^1.1.0",
-            "core-js": "^1.0.0",
-            "debug": "^2.1.1",
-            "detect-indent": "^3.0.0",
-            "esutils": "^2.0.0",
-            "fs-readdir-recursive": "^0.1.0",
-            "globals": "^6.4.0",
-            "home-or-tmp": "^1.0.0",
-            "is-integer": "^1.0.4",
-            "js-tokens": "1.0.1",
-            "json5": "^0.4.0",
-            "lodash": "^3.10.0",
-            "minimatch": "^2.0.3",
-            "output-file-sync": "^1.1.0",
-            "path-exists": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "private": "^0.1.6",
-            "regenerator": "0.8.40",
-            "regexpu": "^1.3.0",
-            "repeating": "^1.1.2",
-            "resolve": "^1.1.6",
-            "shebang-regex": "^1.0.0",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.0",
-            "source-map-support": "^0.2.10",
-            "to-fast-properties": "^1.0.0",
-            "trim-right": "^1.0.0",
-            "try-resolve": "^1.0.0"
+            "ensure-posix-path": "^1.0.1"
           }
         },
-        "babylon": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
-          "dev": true
-        },
-        "broccoli-babel-transpiler": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
-          "dev": true,
-          "requires": {
-            "babel-core": "^5.0.0",
-            "broccoli-funnel": "^1.0.0",
-            "broccoli-merge-trees": "^1.0.0",
-            "broccoli-persistent-filter": "^1.4.2",
-            "clone": "^0.2.0",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^3.5.0",
-            "workerpool": "^2.2.1"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-              "dev": true
-            }
-          }
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        },
-        "detect-indent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "^4.0.1",
-            "minimist": "^1.1.0",
-            "repeating": "^1.1.0"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "^5.6.2",
-            "broccoli-funnel": "^1.0.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^1.0.2",
-            "resolve": "^1.1.2"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+        "babel-plugin-debug-macros": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
+          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
           "dev": true,
           "requires": {
             "semver": "^5.3.0"
           }
         },
-        "globals": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
-          "dev": true
-        },
-        "home-or-tmp": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.13.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
+          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
           "dev": true,
           "requires": {
-            "os-tmpdir": "^1.0.1",
-            "user-home": "^1.1.1"
+            "ember-rfc176-data": "^0.3.13"
           }
         },
-        "js-tokens": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+        "babel-preset-env": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+          "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "babel-plugin-check-es2015-constants": "^6.22.0",
+            "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+            "babel-plugin-transform-async-to-generator": "^6.22.0",
+            "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+            "babel-plugin-transform-es2015-classes": "^6.23.0",
+            "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+            "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+            "babel-plugin-transform-es2015-for-of": "^6.23.0",
+            "babel-plugin-transform-es2015-function-name": "^6.22.0",
+            "babel-plugin-transform-es2015-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+            "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+            "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+            "babel-plugin-transform-es2015-object-super": "^6.22.0",
+            "babel-plugin-transform-es2015-parameters": "^6.23.0",
+            "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+            "babel-plugin-transform-es2015-spread": "^6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+            "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+            "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+            "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+            "babel-plugin-transform-regenerator": "^6.22.0",
+            "browserslist": "^3.2.6",
+            "invariant": "^2.2.2",
+            "semver": "^5.3.0"
           }
         },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+        "broccoli-babel-transpiler": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
+          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
+          "dev": true,
+          "requires": {
+            "babel-core": "^6.26.0",
+            "broccoli-funnel": "^2.0.1",
+            "broccoli-merge-trees": "^2.0.0",
+            "broccoli-persistent-filter": "^1.4.3",
+            "clone": "^2.0.0",
+            "hash-for-dep": "^1.2.3",
+            "heimdalljs-logger": "^0.1.7",
+            "json-stable-stringify": "^1.0.0",
+            "rsvp": "^4.8.2",
+            "workerpool": "^2.3.0"
+          }
+        },
+        "broccoli-file-creator": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz",
+          "integrity": "sha512-YpjOExWr92C5vhnK0kmD81kM7U09kdIRZk9w4ZDCDHuHXW+VE/x6AGEOQQW3loBQQ6Jk+k+TSm8dESy4uZsnjw==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.1.0",
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^1.0.1"
+          }
+        },
+        "browserslist": {
+          "version": "3.2.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+          "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000844",
+            "electron-to-chromium": "^1.3.47"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001581",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz",
+          "integrity": "sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==",
           "dev": true
         },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+        "electron-to-chromium": {
+          "version": "1.4.650",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.650.tgz",
+          "integrity": "sha512-sYSQhJCJa4aGA1wYol5cMQgekDBlbVfTRavlGZVr3WZpDdOPcp6a6xUnFfrt8TqZhsBYYbDxJZCjGfHuGupCRQ==",
+          "dev": true
+        },
+        "ember-cli-babel": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
           "dev": true,
           "requires": {
-            "is-finite": "^1.0.0"
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "^0.2.0-beta.6",
+            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-preset-env": "^1.7.0",
+            "broccoli-babel-transpiler": "^6.5.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^2.1.2",
+            "semver": "^5.5.0"
           }
         },
-        "source-map-support": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+        "ember-cli-version-checker": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
           "dev": true,
           "requires": {
-            "source-map": "0.1.32"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
           }
+        },
+        "ember-rfc176-data": {
+          "version": "0.3.18",
+          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.18.tgz",
+          "integrity": "sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==",
+          "dev": true
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+          "dev": true
         }
       }
     },
@@ -3821,6 +3799,16 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
           "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck="
         }
+      }
+    },
+    "ember-native-dom-helpers": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/ember-native-dom-helpers/-/ember-native-dom-helpers-0.6.3.tgz",
+      "integrity": "sha512-eQTHSV4OBS5YmGLvjgCcit79akG98YVRrcNq/rOVntPX1oq0LQqlPiXtDvDcqSdDur8GyUz6jY1Jy8Y6DLFiSw==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "^1.1.0",
+        "ember-cli-babel": "^6.6.0"
       }
     },
     "ember-promise-tools": {
@@ -4687,12 +4675,6 @@
           }
         }
       }
-    },
-    "ember-test-helpers": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz",
-      "integrity": "sha1-+GTN9vTnXz+HaNZTd4W1q26C2Qc=",
-      "dev": true
     },
     "ember-truth-helpers": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-kinetic-form",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-htmlbars-inline-precompile": "^0.4.3",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-page-object": "^1.11.0",
+    "ember-cli-page-object": "^1.16.0",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -55,5 +55,9 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "volta": {
+    "node": "10.22.0",
+    "yarn": "1.22.17"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-kinetic-form",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/tests/dummy/app/controllers/kinetic-form.js
+++ b/tests/dummy/app/controllers/kinetic-form.js
@@ -12,6 +12,7 @@ export default Controller.extend({
       alert('fake sent');
     },
     update() {
+      // eslint-disable-next-line no-console
       console.log('update fired');
     }
   }

--- a/tests/dummy/app/controllers/nested-section-form.js
+++ b/tests/dummy/app/controllers/nested-section-form.js
@@ -1,0 +1,25 @@
+import Controller from '@ember/controller';
+import { reads } from '@ember/object/computed';
+
+export default Controller.extend({
+  sampleDefinition: reads('model'),
+
+  // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
+  sampleModel: {},
+
+  actions: {
+    sendToServer() {
+      alert('fake sent');
+    },
+    update() {
+      // eslint-disable-next-line no-undef
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          // eslint-disable-next-line no-console
+          console.log('update fired');
+          return resolve();
+        }, 3000);
+      });
+    },
+  },
+});

--- a/tests/dummy/app/controllers/semantic-ui-kinetic-form.js
+++ b/tests/dummy/app/controllers/semantic-ui-kinetic-form.js
@@ -15,8 +15,11 @@ export default Controller.extend({
       alert('fake sent');
     },
     update() {
-      return new Promise((resolve, reject) => {
+
+      // eslint-disable-next-line no-undef
+      return new Promise((resolve) => {
         setTimeout(() => {
+          // eslint-disable-next-line no-console
           console.log('update fired');
           return resolve();
         }, 3000);

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('kinetic-form');
   this.route('semantic-ui-kinetic-form');
   this.route('override-form');
+  this.route('nested-section-form');  
 });
 
 export default Router;

--- a/tests/dummy/app/routes/nested-section-form.js
+++ b/tests/dummy/app/routes/nested-section-form.js
@@ -1,0 +1,48 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  model() {
+    return {
+      schema: {
+        title: 'foobar',
+        type: 'object',
+        properties: {
+          2: {
+            type: 'boolean',
+            title: 'bar craig',
+          },
+          4: {
+            type: 'boolean',
+            title: 'frotz',
+          },
+          7: {
+            type: 'instructions',
+            title: 'Here are my instructions',
+          },
+          8: {
+            type: 'multiplechoice',
+            title: 'Choose many',
+            multiple_choice_options: ['Happy', 'Sad', 'Undecided'],
+            allow_multiple_choice: true,
+          },
+        },
+        required: ['7', '8'],
+      },
+      form: [
+        { key: '4', type: 'boolean' },
+        {
+          type: 'section',
+          title: 'Section 1',
+          items: [
+            { key: '2', type: 'radio' },
+            {
+              type: 'section',
+              title: 'Nested Section',
+              items: ['7', '8'],
+            }
+          ]
+        },
+      ],
+    };
+  },
+});

--- a/tests/dummy/app/routes/nested-section-form.js
+++ b/tests/dummy/app/routes/nested-section-form.js
@@ -17,7 +17,7 @@ export default Route.extend({
           },
           7: {
             type: 'instructions',
-            title: 'Here are my instructions',
+            title: 'Here are my instructions\nStep 1 - - -\nStep 2 - - -',
           },
           8: {
             type: 'multiplechoice',
@@ -26,7 +26,7 @@ export default Route.extend({
             allow_multiple_choice: true,
           },
         },
-        required: ['7', '8'],
+        required: ['8'],
       },
       form: [
         { key: '4', type: 'boolean' },

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,6 +2,7 @@
 
 {{link-to "Generic Example" "kinetic-form" class="ui button"}}
 {{link-to "Semantic-UI Example" "semantic-ui-kinetic-form" class="ui button"}}
+{{link-to "Nested Section Example" "nested-section-form" class="ui button"}}
 
 <hr>
 

--- a/tests/dummy/app/templates/nested-section-form.hbs
+++ b/tests/dummy/app/templates/nested-section-form.hbs
@@ -1,0 +1,5 @@
+{{semantic-ui-kinetic-form
+    definition=sampleDefinition
+    model=sampleModel
+    onUpdate=(action "update")
+    onSubmit=(action "sendToServer")}}

--- a/tests/integration/components/kinetic-form-test.js
+++ b/tests/integration/components/kinetic-form-test.js
@@ -199,6 +199,7 @@ test('calls onUpdate action when user updates the form', async function () {
   set(this, 'updateSpy', sinon.spy());
   set(this, 'testDefinition', {
     schema: {
+      type: 'object',
       properties: {
         fieldA: {type: 'string'},
       }
@@ -215,29 +216,6 @@ test('calls onUpdate action when user updates the form', async function () {
   run(() => page.stringField.enterText('foobar'));
   await settled();
   sinon.assert.calledWith(get(this, 'updateSpy'), sinon.match(isChangeset, 'Changeset'));
-});
-
-test('does not call onUpdate action when user updates the form but is invalid', async function () {
-  set(this, 'updateSpy', sinon.spy());
-  set(this, 'testDefinition', {
-    schema: {
-      required: ['fieldA'],
-      properties: {
-        fieldA: {type: 'string'},
-      }
-    }
-  });
-  page.render(hbs`
-    {{kinetic-form
-        updateDebounceDelay=0
-        definition=testDefinition
-        model=testModel
-        onUpdate=(action updateSpy)
-        onSubmit=(action submitSpy)}}
-  `);
-  run(() => page.stringField.enterText(''));
-  await settled();
-  sinon.assert.notCalled(get(this, 'updateSpy'));
 });
 
 test('shows loading component when passed a promise', function (assert) {

--- a/tests/integration/components/kinetic-form/section-test.js
+++ b/tests/integration/components/kinetic-form/section-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import page from '../../../pages/components/kinetic-form/section';
+import page, { pageWithSubSection } from '../../../pages/components/kinetic-form/section';
 
 const { set } = Ember;
 
@@ -27,14 +27,45 @@ test('displays provides a linkable anchor', function(assert) {
   assert.equal(page.anchor, 'test-title');
 });
 
-test('yields field.items', function(assert) {
-  set(this, 'testField', {title: 'test-title', items: ['1', '2', '3']});
-  page.render(hbs`
-    {{#kinetic-form/section field=testField as |item|}}
-      test-{{item}}
-    {{/kinetic-form/section}}
-  `);
-  assert.ok(page.contains('test-1'), 'expected item 1 to be yielded');
-  assert.ok(page.contains('test-2'), 'expected item 2 to be yielded');
-  assert.ok(page.contains('test-3'), 'expected item 3 to be yielded');
+test('displays section items', function (assert) {
+  set(this, 'testField', {
+    title: 'test-title',
+    items: [
+      { key: '1', type: 'instructions', title: '1. Heat\n2. Pour', componentName: 'semantic-ui-kinetic-form/instructions' },
+      { key: '2', type: 'passfail', title: 'To be or not', required: false, componentName: 'semantic-ui-kinetic-form/passfail' },
+      { key: '3', type: 'boolean', title: 'Reality [] box', required: true, componentName: 'semantic-ui-kinetic-form/boolean' },
+    ]
+  });
+  set(this, 'noop', function() {})
+  page.render(hbs`{{kinetic-form/section field=testField update=noop}}`);
+
+  assert.ok(page.contains('1. Heat\n2. Pour'), 'expected form element 1 to be rendered');
+  assert.ok(page.contains('To be or not'), 'expected form element 2 to be rendered');
+  assert.ok(page.contains('Reality [] box'), 'expected form element 3 to be rendered');
+});
+
+test('displays sub-sections', function (assert) {
+  set(this, 'testField', {
+    title: 'test-title',
+    items: [
+      { key: '1', type: 'instructions', title: '1. Heat\n2. Pour', componentName: 'semantic-ui-kinetic-form/instructions' },
+      {
+        type: 'section',
+        title: 'sub-section',
+        required: false,
+        componentName: 'kinetic-form/section',
+        items: [
+          { key: '2', type: 'passfail', title: 'To be or not', required: false, componentName: 'semantic-ui-kinetic-form/passfail' },
+          { key: '3', type: 'boolean', title: 'Reality [] box', required: true, componentName: 'semantic-ui-kinetic-form/boolean' },
+        ]
+      }
+    ]
+  });
+  set(this, 'noop', function() {})
+  page.render(hbs`<div id="test-parent">{{kinetic-form/section field=testField update=noop}}</div>`);
+
+  assert.ok(pageWithSubSection.contains('1. Heat\n2. Pour'), 'expected form element 1 to be rendered');
+  assert.ok(pageWithSubSection.contains('sub-section'), 'expected sub-section title to be rendered');
+  assert.ok(pageWithSubSection.contains('To be or not'), 'expected form element 2 to be rendered');
+  assert.ok(pageWithSubSection.contains('Reality [] box'), 'expected form element 3 to be rendered');
 });

--- a/tests/integration/components/kinetic-form/section-test.js
+++ b/tests/integration/components/kinetic-form/section-test.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
+import { default as settled } from 'ember-test-helpers/wait';
+import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 import page, { pageWithSubSection } from '../../../pages/components/kinetic-form/section';
 
-const { set } = Ember;
+const { run, set } = Ember;
 
 moduleForComponent('kinetic-form/section', 'Integration | Component | kinetic form/section', {
   integration: true,
@@ -37,7 +39,7 @@ test('displays section items', function (assert) {
     ]
   });
   set(this, 'noop', function() {})
-  page.render(hbs`{{kinetic-form/section field=testField update=noop}}`);
+  page.render(hbs`{{kinetic-form/section field=testField update=noop updateAction=noop}}`);
 
   assert.ok(page.contains('1. Heat\n2. Pour'), 'expected form element 1 to be rendered');
   assert.ok(page.contains('To be or not'), 'expected form element 2 to be rendered');
@@ -62,10 +64,47 @@ test('displays sub-sections', function (assert) {
     ]
   });
   set(this, 'noop', function() {})
-  page.render(hbs`<div id="test-parent">{{kinetic-form/section field=testField update=noop}}</div>`);
+  page.render(hbs`<div id="test-parent">{{kinetic-form/section field=testField update=noop updateAction=noop}}</div>`);
 
   assert.ok(pageWithSubSection.contains('1. Heat\n2. Pour'), 'expected form element 1 to be rendered');
   assert.ok(pageWithSubSection.contains('sub-section'), 'expected sub-section title to be rendered');
   assert.ok(pageWithSubSection.contains('To be or not'), 'expected form element 2 to be rendered');
   assert.ok(pageWithSubSection.contains('Reality [] box'), 'expected form element 3 to be rendered');
+});
+
+test('passes through the update action', function () {
+  const updateActionSpy = sinon.spy();
+  set(this, 'updateAction', updateActionSpy);
+  set(this, 'noop', function () {});
+  set(this, 'testField', {
+    title: 'test-title',
+    items: [
+      {
+        type: 'section',
+        title: 'sub-section',
+        required: false,
+        componentName: 'kinetic-form/section',
+        items: [
+          {
+            key: '1',
+            type: 'boolean',
+            title: 'Is it complete',
+            required: true,
+            componentName: 'kinetic-form/boolean',
+          },
+        ],
+      },
+    ],
+  });
+
+  page.render(hbs`<div id="test-parent">{{kinetic-form/section field=testField updateAction=updateAction update=noop}}</div>`);
+
+  run(() => pageWithSubSection.booleanField.toggle());
+  settled();
+
+  sinon.assert.calledWith(
+    updateActionSpy,
+    '1', // key
+    true,  // value
+  );
 });

--- a/tests/integration/components/semantic-ui-kinetic-form/section-test.js
+++ b/tests/integration/components/semantic-ui-kinetic-form/section-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import page from '../../../pages/components/semantic-ui-kinetic-form/section';
+import page, { pageWithSubSection } from '../../../pages/components/semantic-ui-kinetic-form/section';
 
 const { set } = Ember;
 
@@ -27,14 +27,46 @@ test('displays provides a linkable anchor', function(assert) {
   assert.equal(page.anchor, 'test-title');
 });
 
-test('yields field.items', function(assert) {
-  set(this, 'testField', {title: 'test-title', items: ['1', '2', '3']});
-  page.render(hbs`
-    {{#semantic-ui-kinetic-form/section field=testField as |item|}}
-      test-{{item}}
-    {{/semantic-ui-kinetic-form/section}}
-  `);
-  assert.ok(page.contains('test-1'), 'expected item 1 to be yielded');
-  assert.ok(page.contains('test-2'), 'expected item 2 to be yielded');
-  assert.ok(page.contains('test-3'), 'expected item 3 to be yielded');
+
+test('displays section items', function (assert) {
+  set(this, 'testField', {
+    title: 'test-title',
+    items: [
+      { key: '1', type: 'instructions', title: '1. Heat\n2. Pour', componentName: 'semantic-ui-kinetic-form/instructions' },
+      { key: '2', type: 'passfail', title: 'To be or not', required: false, componentName: 'semantic-ui-kinetic-form/passfail' },
+      { key: '3', type: 'boolean', title: 'Reality [] box', required: true, componentName: 'semantic-ui-kinetic-form/boolean' },
+    ]
+  });
+  set(this, 'noop', function() {})
+  page.render(hbs`{{semantic-ui-kinetic-form/section field=testField update=noop}}`);
+
+  assert.ok(page.contains('1. Heat\n2. Pour'), 'expected form element 1 to be rendered');
+  assert.ok(page.contains('To be or not'), 'expected form element 2 to be rendered');
+  assert.ok(page.contains('Reality [] box'), 'expected form element 3 to be rendered');
 });
+
+test('displays sub-sections', function (assert) {
+  set(this, 'testField', {
+    title: 'test-title',
+    items: [
+      { key: '1', type: 'instructions', title: '1. Heat\n2. Pour', componentName: 'semantic-ui-kinetic-form/instructions' },
+      {
+        type: 'section',
+        title: 'sub-section',
+        required: false,
+        componentName: 'semantic-ui-kinetic-form/section',
+        items: [
+          { key: '2', type: 'passfail', title: 'To be or not', required: false, componentName: 'semantic-ui-kinetic-form/passfail' },
+          { key: '3', type: 'boolean', title: 'Reality [] box', required: true, componentName: 'semantic-ui-kinetic-form/boolean' },
+        ]
+      }
+    ]
+  });
+  set(this, 'noop', function() {})
+  page.render(hbs`<div id="test-parent">{{semantic-ui-kinetic-form/section field=testField update=noop}}</div>`);
+
+  assert.ok(pageWithSubSection.contains('1. Heat\n2. Pour'), 'expected form element 1 to be rendered');
+  assert.ok(pageWithSubSection.contains('sub-section'), 'expected sub-section title to be rendered');
+  assert.ok(pageWithSubSection.contains('To be or not'), 'expected form element 2 to be rendered');
+  assert.ok(pageWithSubSection.contains('Reality [] box'), 'expected form element 3 to be rendered');
+});  

--- a/tests/pages/components/kinetic-form/section.js
+++ b/tests/pages/components/kinetic-form/section.js
@@ -9,4 +9,13 @@ export const KineticFormSection = {
   hasInTitle: contains('h2')
 };
 
+const KineticFormWithSubSection = {
+  scope: '#test-parent > .kinetic-form--section',
+  anchor: attribute('id', 'h2'),
+  title: text('h2'),
+  hasInTitle: contains('h2')
+};
+const pageWithSubSection = PageObject.create(KineticFormWithSubSection);
+
 export default PageObject.create(KineticFormSection);
+export { pageWithSubSection };

--- a/tests/pages/components/kinetic-form/section.js
+++ b/tests/pages/components/kinetic-form/section.js
@@ -1,4 +1,5 @@
 import PageObject from 'ember-cli-page-object';
+import { KineticFormBoolean } from './boolean';
 
 const { attribute, contains, text } = PageObject;
 
@@ -13,7 +14,8 @@ const KineticFormWithSubSection = {
   scope: '#test-parent > .kinetic-form--section',
   anchor: attribute('id', 'h2'),
   title: text('h2'),
-  hasInTitle: contains('h2')
+  hasInTitle: contains('h2'),
+  booleanField: KineticFormBoolean,
 };
 const pageWithSubSection = PageObject.create(KineticFormWithSubSection);
 

--- a/tests/pages/components/semantic-ui-kinetic-form/section.js
+++ b/tests/pages/components/semantic-ui-kinetic-form/section.js
@@ -1,4 +1,5 @@
 import PageObject from 'ember-cli-page-object';
+import { SemanticUIKineticFormBoolean } from './boolean';
 
 const { attribute, contains, text } = PageObject;
 
@@ -13,7 +14,8 @@ const KineticFormWithSubSection = {
   scope: '#test-parent > .semantic-ui-kinetic-form--section',
   anchor: attribute('id', '.header'),
   title: text('header'),
-  hasInTitle: contains('header')
+  hasInTitle: contains('header'),
+  booleanField: SemanticUIKineticFormBoolean,
 };
 const pageWithSubSection = PageObject.create(KineticFormWithSubSection);
 

--- a/tests/pages/components/semantic-ui-kinetic-form/section.js
+++ b/tests/pages/components/semantic-ui-kinetic-form/section.js
@@ -9,4 +9,13 @@ export const KineticFormSection = {
   hasInTitle: contains('.header')
 };
 
+const KineticFormWithSubSection = {
+  scope: '#test-parent > .semantic-ui-kinetic-form--section',
+  anchor: attribute('id', '.header'),
+  title: text('header'),
+  hasInTitle: contains('header')
+};
+const pageWithSubSection = PageObject.create(KineticFormWithSubSection);
+
 export default PageObject.create(KineticFormSection);
+export { pageWithSubSection };

--- a/tests/unit/-schema-form-parser-test.js
+++ b/tests/unit/-schema-form-parser-test.js
@@ -102,6 +102,7 @@ module('Unit | Schema Form Parser', function() {
 
   test('parses form elements with items list', function() {
     let subject = SchemaFormParser.create({
+      lookupComponentName: (type) => `kinetic-form/${type}`,
       schema: {
         type: 'object',
         properties: {
@@ -110,17 +111,18 @@ module('Unit | Schema Form Parser', function() {
           '3': { type: 'boolean', title: 'baz' }
         }
       },
-      form: ["1", { type: 'section', items: ['2', '3'] }]
+      form: ['1', { type: 'section', title: 'my-section', items: ['2', '3'] }],
     });
     sinon.assert.match(subject.get('elements'), [
-      sinon.match({ key: '1', type: 'boolean', title: 'foo' }),
+      sinon.match({ key: '1', type: 'boolean', title: 'foo', required: false }),
       sinon.match({
         type: 'section',
+        title: 'my-section',
         items: [
-          sinon.match({ key: '2', type: 'boolean', title: 'bar' }),
-          sinon.match({ key: '3', type: 'boolean', title: 'baz' })
-        ]
-      })
+          sinon.match({ key: '2', type: 'boolean', title: 'bar', required: false, componentName: 'kinetic-form/boolean' }),
+          sinon.match({ key: '3', type: 'boolean', title: 'baz', required: false, componentName: 'kinetic-form/boolean' }),
+        ],
+      }),
     ]);
   });
 
@@ -160,6 +162,129 @@ module('Unit | Schema Form Parser', function() {
       sinon.match({ key: '1', type: 'string', title: 'foo', componentName: 'string-test-component-name' }),
       sinon.match({ key: '2', type: 'radio', title: 'bar', componentName: 'radio-test-component-name' }),
       sinon.match({ key: '3', type: 'number', title: 'baz', componentName: 'number-test-component-name' })
+    ]);
+  });
+
+  test('parses sub-sections and their names', function() {
+    let subject = SchemaFormParser.create({
+      lookupComponentName: (type) => `kinetic-form/${type}`,
+      schema: {
+        type: "object",
+        title: "Get refreshed!",
+        required: ["3"],
+        properties: {
+          1: { formtype: "instructions", type: "instructions", section: "following", title: "1. Heat\n2. Pour" },
+          2: { formtype: "passfail", type: "passfail", title: "To be or not", required: false },
+          3: { formtype: "textarea", type: "string", section: "sub-section", title: "Let's see what happens", required: true }
+        }
+      },
+      form: [
+        { key: "2", type: "passfail" },
+        { 
+          type: "section",
+          title: "following",
+          items: [
+            { key: "1", type: "instructions" },
+            {
+              type: "section",
+              title: "sub-section",
+              items: [{ key: "3", type: "textarea" }]
+            }
+          ]
+        }
+      ]
+    });
+
+    sinon.assert.match(subject.get('elements'), [
+      sinon.match({ key: '2', type: 'passfail', title: 'To be or not', required: false, componentName: 'kinetic-form/passfail' }),
+      sinon.match({
+        type: 'section',
+        title: 'following',
+        required: false,
+        componentName: 'kinetic-form/section',
+        items: [
+          sinon.match({ key: '1', type: 'instructions', title: '1. Heat\n2. Pour', required: false, componentName: 'kinetic-form/instructions' }),
+          sinon.match({
+            type: 'section',
+            title: 'sub-section',
+            required: false,
+            componentName: 'kinetic-form/section',
+            items: [
+              sinon.match({ key: '3', type: 'textarea', title: 'Let\'s see what happens', required: true, componentName: 'kinetic-form/textarea' }),
+            ]
+          })
+        ],
+      }),
+    ]);
+  });
+
+  test('parses deep section nesting', function() {
+    let subject = SchemaFormParser.create({
+      lookupComponentName: (type) => `kinetic-form/${type}`,
+      schema: {
+        type: "object",
+        title: "Get refreshed!",
+        required: ["3"],
+        properties: {
+          1: { formtype: "instructions", type: "instructions", section: "following", title: "1. Heat\n2. Pour" },
+          2: { formtype: "passfail", type: "passfail", title: "To be or not", required: false },
+          3: { formtype: "textarea", type: "string", section: "sub-section", title: "Let's see what happens", required: true }
+        }
+      },
+      form: [
+        { 
+          type: "section",
+          title: "following",
+          items: [
+            { key: "1", type: "instructions" },
+            {
+              type: "section",
+              title: "sub-section",
+              items: [
+                { key: "3", type: "textarea" },
+                {
+                  type: "section",
+                  title: "deep-sub-section",
+                  items: [
+                    { key: "2", type: "passfail" }
+                  ]
+                }
+    
+              ]
+            }
+          ]
+        }
+      ]
+    });
+
+    sinon.assert.match(subject.get('elements'), [
+      sinon.match({
+        type: 'section',
+        title: 'following',
+        required: false,
+        componentName: 'kinetic-form/section',
+        items: [
+          sinon.match({ key: '1', type: 'instructions', title: '1. Heat\n2. Pour', required: false, componentName: 'kinetic-form/instructions' }),
+          sinon.match({
+            type: 'section',
+            title: 'sub-section',
+            required: false,
+            componentName: 'kinetic-form/section',
+            items: [
+              sinon.match({ key: '3', type: 'textarea', title: 'Let\'s see what happens', required: true, componentName: 'kinetic-form/textarea' }),
+              sinon.match({
+                type: 'section',
+                title: 'deep-sub-section',
+                required: false,
+                componentName: 'kinetic-form/section',
+                items: [
+                  sinon.match({ key: '2', type: 'passfail', title: 'To be or not', required: false, componentName: 'kinetic-form/passfail' }),
+                ]
+              })
+            ]
+          })
+        ],
+      }),
     ]);
   });
 });


### PR DESCRIPTION
# [ENG-5484](https://funnelcloud.atlassian.net/browse/ENG-5484)
Previewing a linked template with its own sections, in `lmv-collab`.
![rendering-nested-sections-lmv-collab](https://github.com/funnelcloudinc/ember-kinetic-form/assets/95099065/c4886b56-db1a-417c-a69e-d8fcf3294191)

### CHANGE DESCRIPTION
- updates the templates to recursively render sections
- updates schema-form-parser to recurse when processing the form's sections
- updates `ember-cli-page-object` to fix test failures

[ENG-5484]: https://funnelcloud.atlassian.net/browse/ENG-5484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ