### PR TITLE
[ENG-5608] Required checkboxes that are not checked are still valid in Operator terminal

### DIFF
--- a/addon/validators/is-true.js
+++ b/addon/validators/is-true.js
@@ -1,5 +1,5 @@
 export default function validateIsTrue() {
   return (key, newValue) => {
-    return newValue === true;
+    return newValue === true || `${key} must be selected`;
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-kinetic-form",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/tests/integration/components/kinetic-form-test.js
+++ b/tests/integration/components/kinetic-form-test.js
@@ -291,4 +291,29 @@ module('Integration | Component | kinetic form', function (hooks) {
     );
     assert.ok(page.form.isHidden, 'expected form component to be hidden');
   });
+
+  test('displays validation errors on attempt to submit an invalid form', async function (assert) {
+    set(this, 'testDefinition', {
+      schema: {
+        type: 'object',
+        required: ['textInput', 'checkbox'],
+        properties: {
+          textInput: { type: 'string' },
+          checkbox: { type: 'boolean' },
+        },
+      },
+    });
+    await render(hbs`
+      {{kinetic-form
+          definition=this.testDefinition
+          model=this.testModel}}
+    `);
+    await run(() => page.submit());
+
+    assert.equal(
+      page.errorsSection.messages().count,
+      2,
+      'expected two errors to be displayed'
+    );
+  })
 });

--- a/tests/integration/components/kinetic-form-test.js
+++ b/tests/integration/components/kinetic-form-test.js
@@ -310,10 +310,10 @@ module('Integration | Component | kinetic form', function (hooks) {
     `);
     await run(() => page.submit());
 
-    assert.equal(
+    assert.strictEqual(
       page.errorsSection.messages().count,
       2,
       'expected two errors to be displayed'
     );
-  })
+  });
 });

--- a/tests/unit/validators/is-true-test.js
+++ b/tests/unit/validators/is-true-test.js
@@ -8,10 +8,22 @@ module('Unit | Validators | is-true', function () {
     const errorMessagePattern = /must be selected/;
 
     assert.strictEqual(typeOf(subject), 'function');
-    assert.ok(errorMessagePattern.test(subject('foo', 'bork')), 'expected return value to be false');
-    assert.ok(errorMessagePattern.test(subject('foo', {})), 'expected return value to be false');
-    assert.ok(errorMessagePattern.test(subject('foo', 1)), 'expected return value to be false');
-    assert.ok(errorMessagePattern.test(subject('foo', false)), 'expected return value to be false');
+    assert.ok(
+      errorMessagePattern.test(subject('foo', 'bork')),
+      'expected return value to be false'
+    );
+    assert.ok(
+      errorMessagePattern.test(subject('foo', {})),
+      'expected return value to be false'
+    );
+    assert.ok(
+      errorMessagePattern.test(subject('foo', 1)),
+      'expected return value to be false'
+    );
+    assert.ok(
+      errorMessagePattern.test(subject('foo', false)),
+      'expected return value to be false'
+    );
     assert.ok(subject('foo', true), 'expected return value to be true');
   });
 });

--- a/tests/unit/validators/is-true-test.js
+++ b/tests/unit/validators/is-true-test.js
@@ -4,12 +4,14 @@ import validateIsTrue from 'ember-kinetic-form/validators/is-true';
 
 module('Unit | Validators | is-true', function () {
   test('validates value is true or not', function (assert) {
-    let subject = validateIsTrue();
+    const subject = validateIsTrue();
+    const errorMessagePattern = /must be selected/;
+
     assert.strictEqual(typeOf(subject), 'function');
-    assert.notOk(subject('foo', 'bork'), 'expected return value to be false');
-    assert.notOk(subject('foo', {}), 'expected return value to be false');
-    assert.notOk(subject('foo', 1), 'expected return value to be false');
-    assert.notOk(subject('foo', false), 'expected return value to be false');
+    assert.ok(errorMessagePattern.test(subject('foo', 'bork')), 'expected return value to be false');
+    assert.ok(errorMessagePattern.test(subject('foo', {})), 'expected return value to be false');
+    assert.ok(errorMessagePattern.test(subject('foo', 1)), 'expected return value to be false');
+    assert.ok(errorMessagePattern.test(subject('foo', false)), 'expected return value to be false');
     assert.ok(subject('foo', true), 'expected return value to be true');
   });
 });


### PR DESCRIPTION
# [ENG-5608](https://funnelcloud.atlassian.net/browse/ENG-5608)

### Changes
- updates the `is-true` validator to return a message when validation fails

Note: this seems to reflect a change in the API for `ember-changeset`.

[ENG-5608]: https://funnelcloud.atlassian.net/browse/ENG-5608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ